### PR TITLE
Fix SUSFS 1.5.7 backport patch rejects

### DIFF
--- a/kernel_patches/backport-fs-upstream-susfs-v1.5.7-non-gki.patch
+++ b/kernel_patches/backport-fs-upstream-susfs-v1.5.7-non-gki.patch
@@ -546,27 +546,6 @@ index a2bf0ec64cc8..701d218a2064 100644
  	struct linux_dirent64 __user * previous;
  	int count;
  	int error;
-@@ -311,8 +353,19 @@ static int filldir64(struct dir_context *ctx, const char *name, int namlen,
- 		sizeof(u64));
- 
- #ifdef CONFIG_KSU_SUSFS_SUS_PATH
--	if (likely(current->susfs_task_state & TASK_STRUCT_NON_ROOT_USER_APP_PROC) && susfs_sus_ino_for_filldir64(ino)) {
-+	struct inode *inode;
-+
-+	if (buf->sb->s_magic == FUSE_SUPER_MAGIC && susfs_is_fuse_ino_sus_ino(ino)) {
- 		return 0;
-+	} else {
-+		inode = ilookup(buf->sb, ino);
-+		if (inode) {
-+			if (susfs_need_to_spoof_sus_path(inode,  inode->i_uid.val)) {
-+				iput(inode);
-+				return 0;
-+			}
-+			iput(inode);
-+		}
- 	}
- #endif
- 	buf->error = verify_dirent_name(name, namlen);
 @@ -369,7 +422,9 @@ SYSCALL_DEFINE3(getdents64, unsigned int, fd,
  	f = fdget_pos(fd);
  	if (!f.file)


### PR DESCRIPTION
These lines never existed so when the patch tries to remove these non-existing lines it rejects